### PR TITLE
fix: support TheMovieDb provider ID key from Shokofin plugin

### DIFF
--- a/src/jellyfin_rpc/jellyfin_rpc.py
+++ b/src/jellyfin_rpc/jellyfin_rpc.py
@@ -281,7 +281,9 @@ def run_main_loop(config: SectionProxy, refresh_rate: int):
                 if media_type == 'Episode' and config.get('TMDB_API_KEY'):
                     try:
                         series = jf_api.get_item(media_dict['SeriesId'])
-                        tmdb_id = series['ProviderIds']['Tmdb']
+                        tmdb_id = series['ProviderIds'].get('Tmdb') or series['ProviderIds'].get('TheMovieDb')
+                        if tmdb_id is None:
+                            raise KeyError('Tmdb')
                     except KeyError:
                         logger.warning('No TMDB ID Found. Skipping...')
                     else:
@@ -297,7 +299,9 @@ def run_main_loop(config: SectionProxy, refresh_rate: int):
 
                 elif media_type == 'Movie' and config.get('TMDB_API_KEY'):
                     try:
-                        tmdb_id = media_dict['ProviderIds']['Tmdb']
+                        tmdb_id = media_dict['ProviderIds'].get('Tmdb') or media_dict['ProviderIds'].get('TheMovieDb')
+                        if tmdb_id is None:
+                            raise KeyError('Tmdb')
                     except KeyError:
                         logger.warning('No TMDB ID Found. Skipping...')
                     else:


### PR DESCRIPTION
Series/Movies that were processed by Shoko don't return a tmdb key in their metadata, instead they return "TheMovieDb" as shown below, this causes an issue with the current implementation as the poster never gets properly retrieved. 

The PR fixes this.

```
{'AniDB': '17617', 'Custom': '...', 'Shoko Group': '16', 'Shoko Series': '7', 'TheMovieDb': '209867', 'Tvdb': '424536'}
```