### PR TITLE
Fixed Tray on Linux + Single instance only patch

### DIFF
--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             platform: linux-x86_64
           - os: windows-latest
             platform: windows-amd64
@@ -29,19 +29,22 @@ jobs:
         with:
           enable-cache: true
       - name: Install Python 3.14 (Linux Only)
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-24.04'
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
           sudo add-apt-repository ppa:deadsnakes/ppa -y
           sudo apt-get update
-          sudo apt-get install -y python3.14-tk libpython3.14
+          sudo apt-get install -y python3.14-tk libpython3.14 python3.14-dev gir1.2-ayatanaappindicator3-0.1 gir1.2-gtk-3.0 libgirepository-2.0-dev libgirepository1.0-dev pkg-config libcairo2-dev
           uv venv .venv --python /usr/bin/python3.14 --seed
       - name: Install Python 3.14 (macOS/Windows)
-        if: matrix.os != 'ubuntu-22.04'
+        if: matrix.os != 'ubuntu-24.04'
         run: uv python install 3.14
       - name: Install Dependencies
         run: uv sync --extra gui --no-dev
+      - name: Install PyGObject (Linux Only)
+        if: matrix.os == 'ubuntu-24.04'
+        run: uv pip install "pygobject<3.50"
       - name: Build PyInstaller Executable
         shell: bash
         run: |
@@ -50,9 +53,14 @@ jobs:
           elif [ "${{ matrix.platform }}" = "macos-amd64" ]; then
             export MACOS_ARCH="x86_64"
           fi
-          uv run pyinstaller main.spec --noconfirm
+          if [ "${{ matrix.platform }}" = "linux-x86_64" ]; then
+            sudo apt-get install -y xvfb
+            xvfb-run -a uv run pyinstaller main.spec --noconfirm
+          else
+            uv run pyinstaller main.spec --noconfirm
+          fi
       - name: Generate AppImage (Linux Only)
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-24.04'
         shell: bash
         run: |
           mkdir -p dist/AppDir/usr/bin

--- a/README.md
+++ b/README.md
@@ -33,17 +33,29 @@ If you prefer to use the CLI over the GUI (or you're on Linux), fill out the inc
 > [!IMPORTANT]
 > [TMDB](https://www.themoviedb.org/) can **optionally** be used to fetch posters for movies and TV shows. However, you must create a [TMDB account](https://www.themoviedb.org/signup/) and generate an [API key](https://developer.themoviedb.org/docs/getting-started). [MusicBrainz](https://musicbrainz.org/) and the [Cover Art Archive](https://coverartarchive.org/) can be used to fetch album covers.
 
-- `show_when_paused` shows the activity with a paused timer instead of a progress bar. If disabled, the activity stops displaying when you pause your media.
-- `show_server_name` shows your server name as the activity name instead of saying 'Jellyfin'.
-- `show_jellyfin_icon` shows a small Jellyfin icon in the bottom right of the poster or album cover.
-- `poster_languages` is a comma-separated list of two-letter language codes ([ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1)) for TMDB.
-- `textless_posters` controls whether textless TMDB posters are prioritized over language posters.
-- `always_use_tmdb` controls whether TMDB is the default source for posters or a fallback provider.
-- `season_over_series` controls whether season posters are preferred over series posters for shows.
-- `always_use_musicbrainz` controls whether MusicBrainz (via the Cover Art Archive) is the default source for album covers or a fallback provider.
-- `release_over_group` controls whether release album covers are preferred over group album covers. The distinction between [release](https://musicbrainz.org/doc/Release) and [release group](https://musicbrainz.org/doc/Release_Group) is described in the MusicBrainz documentation. In short, a release is a specific *release* of an album that belongs to a *release group* (one per album).
+- `jellyfin_host` is the base URL of your Jellyfin server, including the scheme and port (e.g. `http://192.168.1.100:8096`).
+- `jellyfin_api_key` is the API key used to authenticate with your Jellyfin server. Leave blank to use Quick Connect instead.
+- `jellyfin_username` is the Jellyfin username whose activity should be tracked. Leave blank to use Quick Connect instead.
 - `filter_mode` controls whether `filter_libraries` uses a whitelist (allowed) or blacklist (blocked).
 - `filter_libraries` is a comma-separated list of Jellyfin libraries to either whitelist or blacklist.
+- `tmdb_api_key` is your API key for The Movie Database, used to fetch movie and show posters. Leave blank to disable TMDB lookups.
+- `poster_languages` is a comma-separated list of two-letter language codes ([ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1)) for TMDB.
+- `textless_posters` controls whether textless TMDB posters are prioritized over language posters.
+- `season_over_series` controls whether season posters are preferred over series posters for shows.
+- `release_over_group` controls whether release album covers are preferred over group album covers. The distinction between [release](https://musicbrainz.org/doc/Release) and [release group](https://musicbrainz.org/doc/Release_Group) is described in the MusicBrainz documentation. In short, a release is a specific *release* of an album that belongs to a *release group* (one per album).
+- `always_use_tmdb` controls whether TMDB is the default source for posters or a fallback provider.
+- `always_use_musicbrainz` controls whether MusicBrainz (via the Cover Art Archive) is the default source for album covers or a fallback provider.
+- `media_types` is a comma-separated list of media types to track activity for. Valid values are `Movies`, `Shows`, and `Music`.
+- `show_when_paused` shows the activity with a paused timer instead of a progress bar. If disabled, the activity stops displaying when you pause your media.
+- `show_server_name` shows your server name as the activity name instead of saying 'Jellyfin'.
+- `show_jellyfin_logo` shows a small Jellyfin icon in the bottom right of the poster or album cover.
+- `polling_rate` is the interval, in seconds, at which Jellyfin RPC checks for playback changes.
+- `seek_threshold` is the minimum change in playback position, in seconds, required to be treated as a seek rather than normal playback.
+- `log_level` controls the verbosity of log messages shown in the GUI and printed to the console. Valid values are `DEBUG`, `INFO`, `WARNING`, `ERROR`, and `CRITICAL`.
+- `file_hdlr_level` controls the verbosity of log messages written to the log file, independently of `log_level`.
+- `log_max_bytes` is the maximum size, in bytes, a log file is allowed to reach before it is rotated.
+- `log_max_files` is the number of rotated log files to keep before the oldest is deleted.
+- `singleton_port` is the local port used to detect whether Jellyfin RPC is already running, so that opening it again focuses the existing window instead of starting a second instance. Change this only if the default port conflicts with another application on your system.
 
 ## GUI Screenshot
 

--- a/jellyfin_rpc.ini
+++ b/jellyfin_rpc.ini
@@ -21,4 +21,5 @@ log_level = INFO
 file_hdlr_level = DEBUG
 log_max_bytes = 5242880
 log_max_files = 3
+singleton_port = 57634
 

--- a/main.spec
+++ b/main.spec
@@ -1,21 +1,63 @@
 # -*- mode: python ; coding: utf-8 -*-
 import os
+import glob
 import platform
-
 from PyInstaller.utils.hooks import collect_data_files
+
+extra_binaries = []
+extra_datas = []
+
+if platform.system() == 'Linux':
+    typelib_dirs = [
+        '/usr/lib/x86_64-linux-gnu/girepository-1.0',
+        '/usr/lib/x86_64-linux-gnu/girepository-2.0',
+    ]
+    typelib_names = [
+        'GLib-2.0', 'GObject-2.0', 'Gio-2.0', 'GioUnix-2.0',
+        'Gtk-3.0', 'Gdk-3.0', 'GdkPixbuf-2.0', 'Atk-1.0',
+        'Pango-1.0', 'HarfBuzz-0.0', 'cairo-1.0', 'freetype2-2.0',
+        'xlib-2.0', 'GModule-2.0', 'GLibUnix-2.0',
+        'AyatanaAppIndicator3-0.1', 'AppIndicator3-0.1',
+        'DBus-1.0', 'DBusGLib-1.0',
+    ]
+    for typelib_dir in typelib_dirs:
+        for name in typelib_names:
+            for path in glob.glob(os.path.join(typelib_dir, f'{name}.typelib')):
+                extra_datas.append((path, 'gi_typelibs'))
+
+    lib_dirs = ['/usr/lib/x86_64-linux-gnu']
+    lib_patterns = [
+        'libayatana-appindicator3*',
+        'libayatana-indicator3*',
+        'libayatana-ido3*',
+        'libappindicator3*',
+    ]
+    for lib_dir in lib_dirs:
+        for pattern in lib_patterns:
+            for path in glob.glob(os.path.join(lib_dir, pattern)):
+                extra_binaries.append((path, '.'))
 
 a = Analysis(
     ['src/jellyfin_rpc/app.py'],
     pathex=[],
-    binaries=[],
+    binaries=extra_binaries,
     datas=[
         ('jellyfin_rpc.ini', '.'),
         ('images/icon.png', '.'),
         ('images/icon.ico', '.'),
         *collect_data_files('certifi'),
         *collect_data_files('language_data'),
+        *extra_datas,
     ],
-    hiddenimports=[],
+    hiddenimports=[
+        'gi',
+        'gi.repository.GLib',
+        'gi.repository.GObject',
+        'gi.repository.Gio',
+        'gi.repository.Gtk',
+        'gi.repository.GdkPixbuf',
+        'gi.repository.AyatanaAppIndicator3',
+    ],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
@@ -24,7 +66,6 @@ a = Analysis(
     optimize=0,
 )
 pyz = PYZ(a.pure)
-
 exe = EXE(
     pyz,
     a.scripts,
@@ -46,7 +87,6 @@ exe = EXE(
     entitlements_file=None,
     icon=['images/icon.ico'],
 )
-
 if platform.system() == 'Darwin':
     coll = COLLECT(
         exe,

--- a/src/jellyfin_rpc/app.py
+++ b/src/jellyfin_rpc/app.py
@@ -4,22 +4,22 @@ import multiprocessing as mp
 import os
 import queue
 import shutil
+import socket
 import subprocess
 import sys
 import threading
 import webbrowser
-from configparser import ConfigParser, SectionProxy
-from json.decoder import JSONDecodeError
-from logging import LogRecord, handlers
-from multiprocessing.queues import Queue
-from typing import Any, Callable, TypedDict, cast
-
 import certifi
 import customtkinter as ctk
 import pystray
 import requests
 from PIL import Image
 from requests.exceptions import RequestException
+from configparser import ConfigParser, SectionProxy
+from json.decoder import JSONDecodeError
+from logging import LogRecord, handlers
+from multiprocessing.queues import Queue
+from typing import Any, Callable, TypedDict, cast
 
 from jellyfin_rpc import __version__, start_discord_rpc
 from jellyfin_rpc.main import (
@@ -321,7 +321,7 @@ def on_close(
 def set_close_behavior(
     root: ctk.CTk, on_close_callback: Callable[[], None], withdraw: bool
 ) -> None:
-    if withdraw and sys.platform != 'linux':
+    if withdraw:
         root.protocol('WM_DELETE_WINDOW', root.withdraw)
     else:
         root.protocol('WM_DELETE_WINDOW', on_close_callback)
@@ -475,6 +475,38 @@ def setup_logging(log_level: int | str, log_path: str | None = None) -> Queue[Lo
     return log_queue
 
 
+def acquire_singleton_lock(port: int) -> bool:
+    global _singleton_socket
+    _singleton_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        _singleton_socket.bind(('127.0.0.1', port))
+        _singleton_socket.listen(1)
+        _singleton_socket.setblocking(False)
+        return True
+    except OSError:
+        try:
+            notify_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            notify_socket.connect(('127.0.0.1', port))
+            notify_socket.sendall(b'FOCUS')
+            notify_socket.close()
+        except OSError:
+            pass
+        return False
+
+
+def poll_singleton_socket(root: ctk.CTk) -> None:
+    if _singleton_socket is not None:
+        try:
+            conn, _ = _singleton_socket.accept()
+            conn.close()
+            root.after(0, root.deiconify)
+            root.after(0, root.lift)
+            root.after(0, root.focus_force)
+        except BlockingIOError:
+            pass
+    root.after(200, lambda: poll_singleton_socket(root))
+
+
 def main() -> None:
     ini_name, log_name = 'jellyfin_rpc.ini', 'jellyfin_rpc.log'
     bundle_dir = getattr(sys, '_MEIPASS', os.path.abspath(os.path.dirname(__file__)))
@@ -508,6 +540,11 @@ def main() -> None:
             shutil.copyfile(ini_bundle_path, ini_path)
 
     config = load_config(ini_path)
+
+    # If another instance is already listening on this port, notify it and exit immediately
+    singleton_port = config.getint('SINGLETON_PORT', fallback=57634)
+    if not acquire_singleton_lock(singleton_port):
+        return
 
     jf_host = config.get('JELLYFIN_HOST', '')
     jf_api_key = config.get('JELLYFIN_API_KEY', '')
@@ -547,6 +584,9 @@ def main() -> None:
     root.title(f'Jellyfin RPC v{__version__}')
     root.rowconfigure(0, weight=1)
     root.columnconfigure(0, weight=1)
+    
+    # Bring this window to the front whenever a second instance signals us
+    poll_singleton_socket(root)
 
     frame_main = ctk.CTkFrame(master=root)
     frame_main.grid(row=0, column=0, sticky='nsew')
@@ -901,8 +941,6 @@ def main() -> None:
 
     for key, checkbox in checkboxes.items():
         if key == 'MINIMIZE_ON_CLOSE':
-            if sys.platform == 'linux':
-                continue
             checkbox.configure(
                 command=lambda: set_close_behavior(
                     root, on_close_callback, checkboxes['MINIMIZE_ON_CLOSE']._variable.get()
@@ -1017,7 +1055,7 @@ def main() -> None:
             '::tk::mac::ReopenApplication',
             lambda: on_maximize(label_update, frame_grid, frame_bottom, root),
         )
-    elif sys.platform == 'win32':
+    elif sys.platform in ('win32', 'linux'):
         tray_icon = pystray.Icon(
             'jellyfin-rpc',
             Image.open(png_bundle_path),
@@ -1028,7 +1066,7 @@ def main() -> None:
                 pystray.MenuItem('Quit', lambda: gui_queue.put('QUIT')),
             ),
         )
-        tray_icon.run_detached()
+        threading.Thread(target=tray_icon.run, daemon=True).start()
     context['tray_icon'] = tray_icon
 
     button_connect = ctk.CTkButton(
@@ -1039,10 +1077,7 @@ def main() -> None:
     if jf_host:  # and jf_api_key and jf_username:
         on_click_callback()
         if start_minimized and button_connect_text == 'Disconnect':
-            if sys.platform == 'linux':
-                root.iconify()
-            else:
-                root.withdraw()
+            root.withdraw()
     else:
         logger.info('Open Setup Guide')
 


### PR DESCRIPTION
After dealing with it for 2 days I've managed to make it work now in Tray as I said in the issues.

I tested it on Linux Nobara KDE, Linux Mint Cinnamon and Windows and everything seems to work.
Had to update the pyinstaller as packages were missing which are required for Linux to show it in Tray.

I've also added a single-instance check by using a port (I haven't added an option to change it, but users can add/change a variable in the ini file to change the port (README.md shows which it is)

## Summary
Fixes Linux tray icon support (previously broken: no icon, no right-click menu, close button always quit) and adds single-instance handling.

### Changes
- **app.py**: Enable minimize-to-tray on Linux (was disabled), fix tray icon thread handling, start minimized to tray instead of taskbar, add single-instance lock (focuses existing window instead of opening a duplicate)
- **main.spec**: Bundle required GTK/AppIndicator typelibs and shared libraries for Linux builds
- **pyinstaller.yaml**: Switch Linux runner to ubuntu-24.04, install required GTK/AppIndicator dev packages, use xvfb during build, pin pygobject<3.50 for pystray compatibility
- **jellyfin_rpc.ini**: Add `singleton_port` option
- **README.md**: Fix outdated `show_jellyfin_icon` → `show_jellyfin_logo`, document 12 previously undocumented config options + the new port option.